### PR TITLE
feat: tapping the brand icon now takes you to the Home tab

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -76,11 +76,28 @@ const WoodmenDarkIcon = withTheme(({ theme }) => ({
 }))(Icon);
 
 const WoodmenIcon = () => {
+  const navigation = useNavigation();
   const theme = useTheme();
   if (theme.type === 'light') {
-    return <WoodmenLightIcon />;
+    return (
+      <Touchable
+        onPress={() => {
+          navigation.navigate('Home');
+        }}
+      >
+        <WoodmenLightIcon />
+      </Touchable>
+    );
   } else {
-    return <WoodmenDarkIcon />;
+    return (
+      <Touchable
+        onPress={() => {
+          navigation.navigate('Home');
+        }}
+      >
+        <WoodmenDarkIcon />
+      </Touchable>
+    );
   }
 };
 


### PR DESCRIPTION
This is working for iOS, but needs confirmation on Android. Currently having trouble with touchable opacities for this and search not working on Android. That problem only exists on the simulator as far as I can tell. I do not have this problem on my Android physical device.
![2022-02-18 11 31 17](https://user-images.githubusercontent.com/72768221/154733186-2fa77777-b59a-434b-8667-932aa4b4bf5e.gif)

