### PR TITLE
fix: the Campus select button text

### DIFF
--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -81,6 +81,10 @@ const buttons = () => ({
     // Hide Follow Request Button Text
     accent: '#ffffff',
   },
+  // Make select campus text show.
+  secondary: {
+    accent: '#ffffff',
+  },
 });
 
 const overrides = {


### PR DESCRIPTION
This will fix the text not showing up on the select campus button. 

Before changes:
<img width="401" alt="Screen Shot 2022-03-25 at 10 25 30 AM" src="https://user-images.githubusercontent.com/16566029/160150955-5b53c0f0-7159-4f54-8d3d-8bdb7643fd5a.png">

After Changes:
<img width="393" alt="Screen Shot 2022-03-25 at 10 26 47 AM" src="https://user-images.githubusercontent.com/16566029/160151078-15330941-5a0c-4d87-b346-2ec9e520c8ff.png">
