### PR TITLE
fix: featureTitles override to wrap title overflow

### DIFF
--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -123,6 +123,9 @@ const overrides = {
   'ui-connected.RockAuthedWebBrowser': (theme) => ({
     primary: theme.colors.text.secondary,
   }),
+  'ui-kit.FeatureTitles.Container': {
+    flexShrink: 1,
+  },
 };
 
 export default { buttons, colors, overrides, typography };


### PR DESCRIPTION
The purpose of this PR is to fix featureTitles text overflow. Below is a quick demo. 

@conrad-vanl I think someone may have switched the retool config from 'title' to 'subtitle' while I was recording this, which is why the first few titles appear to be subtitles while the rest are still titles. You should still be able to see that this override fixes the overflow issue of titles around 0:12 when the "Woodmen Heights Campus" title is visible.

We can stick with the retool title -> subtitle swap if you'd prefer but I think this is also an option.

https://user-images.githubusercontent.com/19194337/164510275-4aa874a0-bf32-49c5-8922-ae1ba2f61785.mov
