### PR TITLE
fix: hides up next button

### DIFF
--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -123,6 +123,10 @@ const overrides = {
   'ui-connected.RockAuthedWebBrowser': (theme) => ({
     primary: theme.colors.text.secondary,
   }),
+  // Hides the Series Progression Button on Content Items
+  'ui-connected.UpNextButtonConnected.UpNextButton': {
+    display: 'none',
+  },
 };
 
 export default { buttons, colors, overrides, typography };


### PR DESCRIPTION
This override hides the Up Next Button from Content Items. This functionality of this button will likely change very soon as well.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 13 - 2022-04-21 at 12 28 38](https://user-images.githubusercontent.com/72768221/164517360-17907417-800a-4699-8691-369d338fc683.png)|![Simulator Screen Shot - iPhone 13 - 2022-04-21 at 12 28 07](https://user-images.githubusercontent.com/72768221/164517366-a6c1783c-3a23-4ba1-9a46-199cbce9f34f.png)|

